### PR TITLE
fix lsblk detect fs on some devices

### DIFF
--- a/applications/luci-app-diskman/luasrc/model/diskman.lua
+++ b/applications/luci-app-diskman/luasrc/model/diskman.lua
@@ -189,7 +189,7 @@ local get_parted_info = function(device)
         partition_temp["name"] = device.."p"..partition_temp["number"]
       end
       if partition_temp["number"] > 0 and partition_temp["fs"] == "" and d.command.lsblk then
-        partition_temp["fs"] = luci.util.exec(d.command.lsblk .. " /dev/"..device.. tostring(partition_temp["number"]) .. " -no fstype"):match("([^%s]+)") or ""
+        partition_temp["fs"] = (luci.util.exec(d.command.lsblk .. " /dev/" .. partition_temp["name"] .. " -no fstype") or ""):match("([^%s]+)") or ""
       end
       partition_temp["fs"] = partition_temp["fs"] == "" and "raw" or partition_temp["fs"]
       partition_temp["sec_start"] = partition_temp["sec_start"] and partition_temp["sec_start"]:sub(1,-2)


### PR DESCRIPTION
example log:
`lsblk: /dev/mmcblk22: not a block device`
`lsblk: /dev/nvme0n1128: not a block device`
`lsblk: /dev/nvme0n12: not a block device`